### PR TITLE
Expose test results to GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,4 +33,4 @@ jobs:
         run: |
           make copy_srcs
           cd impulse
-          ../GENERATED/BINARIES/impulse/impulse testsuite --fakeroot $(dirname $(pwd))
+          ../GENERATED/BINARIES/impulse/impulse testsuite --fakeroot $(dirname $(pwd)) --github_actions

--- a/impulse.py
+++ b/impulse.py
@@ -182,13 +182,18 @@ def test(
   target:impulse_paths.BuildTarget,
   debug:bool=False,
   fakeroot:args.Directory|None=None,
+  github_actions:bool=False,
 ):
   """Builds a testcase and executes it."""
   ruleinfo = build(target, None, debug, False, fakeroot)
   if not ruleinfo.type.endswith('_test'):
     print(f'Only test targets can be run {ruleinfo.type}')
     return
-  sys.exit(os.WEXITSTATUS(os.system(f'{ruleinfo.output} run')))
+  sys.exit(
+    os.WEXITSTATUS(
+      os.system(f'{ruleinfo.output} run {args.Forward("github_actions")}')
+    )
+  )
 
 
 @command
@@ -196,7 +201,8 @@ def testsuite(
   project:str|None=None,
   debug:bool=False,
   threads:int=6,
-  fakeroot:args.Directory|None=None
+  fakeroot:args.Directory|None=None,
+  github_actions:bool=False,
 ):
   setup(debug, fakeroot)
   targets, buildgraph = graph_for_directory(project, True)
@@ -205,7 +211,9 @@ def testsuite(
   for staged_build_target in targets:
     binary = GetStagedRuleInfo(staged_build_target).output
     print(f'Running `{binary} run`')
-    errcode = os.WEXITSTATUS(os.system(f'{binary} run'))
+    errcode = os.WEXITSTATUS(
+      os.system(f'{binary} run {args.Forward("github_actions")}')
+    )
     if errcode != 0:
       sys.exit(errcode)
 

--- a/testing/testmain.py
+++ b/testing/testmain.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from impulse.args import args
@@ -8,12 +9,16 @@ arguments = args.ArgumentParser(complete=True)
 
 
 @arguments
-def run(notermcolor:bool=False, filter:str|None=None):
+def run(notermcolor:bool=False, filter:str|None=None, github_actions:bool=False):
   """Runs unit tests."""
+  export_as = 'print'
+  if github_actions or os.environ.get('GITHUB_ACTIONS') == 'true':
+    export_as = 'github_actions'
+
   if filter is not None:
-    unittest.TestCase.RunFilter(notermcolor, filter, export_as='print')
+    unittest.TestCase.RunFilter(notermcolor, filter, export_as=export_as)
     sys.exit(1)
-  exit_code = unittest.TestCase.RunAll(notermcolor, export_as='print')
+  exit_code = unittest.TestCase.RunAll(notermcolor, export_as=export_as)
   sys.exit(exit_code)
 
 

--- a/testing/unittest.py
+++ b/testing/unittest.py
@@ -19,10 +19,13 @@ class EarlyExitPassedError(Exception):
 class FailedAssertError(Exception):
   def __init__(self, filename, casename, lineno, assertname, A, B):
     super().__init__()
+    self._filename = filename
+    self._lineno = lineno
     testbase = (__file__ or '')[:-27]
     if filename.startswith(testbase):
       filename = filename[len(testbase):]
     self._file_location = '{}:{}'.format(filename, lineno)
+    self._rel_filename = filename
     self._assertName = assertname
     self._expected = A
     self._actual = B
@@ -310,6 +313,30 @@ class TestCase(object):
     if f_len or c_len:
       return 1
     return 0
+
+  @classmethod
+  def github_actions(cls, out):
+    exit_code = cls.print(out)
+    for f in out['failures']:
+      print(
+        f'::error file={f._rel_filename},line={f._lineno},'
+        f'title={f._casename}::{f._assertName} failed; '
+        f'expected {f._expected}, was {f._actual}'
+      )
+    for c in out['crashes']:
+      tb = c.tb
+      while tb.tb_next:
+        tb = tb.tb_next
+      filename = tb.tb_frame.f_code.co_filename
+      lineno = tb.tb_lineno
+      testbase = (__file__ or '')[:-27]
+      if filename.startswith(testbase):
+        filename = filename[len(testbase):]
+      print(
+        f'::error file={filename},line={lineno},title={c.isolator.name}::'
+        f'Crashed: {c.exc}'
+      )
+    return exit_code
 
   @classmethod
   def PrintFailure(cls, failure:FailedAssertError, max_len:int):


### PR DESCRIPTION
This change adds support for GitHub Actions workflow commands to the Impulse test library. Test failures and crashes are now reported as annotations in the GitHub Actions UI. This is achieved by:
1. Enhancing `FailedAssertError` in `testing/unittest.py` to store raw filename and line number.
2. Adding a `github_actions` export method to `TestCase` that prints `::error` annotations.
3. Updating `testing/testmain.py` to support a `--github_actions` flag and auto-detect when running in CI.
4. Forwarding the flag from the main `impulse` tool to individual test binaries.
5. Updating the CI workflow to use this new feature.

---
*PR created automatically by Jules for task [26769470096718701](https://jules.google.com/task/26769470096718701) started by @tmathmeyer*