### PR TITLE
Automate GitHub Releases for Impulse Binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,40 @@
+name: Release Impulse
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            fuse3 \
+            fuse-overlayfs \
+            libfuse-dev \
+            python3 make
+
+      - name: Build Impulse
+        run: make
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ github.run_number }}
+          name: Release v${{ github.run_number }}
+          body: |
+            Automated build of the impulse binary from the master branch.
+            Commit: ${{ github.sha }}
+          draft: false
+          prerelease: false
+          files: GENERATED/BINARIES/impulse/impulse
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I have created a new GitHub Actions workflow file `.github/workflows/release.yaml` that automates the creation of GitHub releases. This workflow triggers on every push to the `master` branch, installs the required system dependencies, builds the `impulse` binary using `make`, and then creates a new release with the binary attached as an asset. I also verified the build process locally by running the test suite using the generated binary to ensure it is functional.

---
*PR created automatically by Jules for task [6049412261437976789](https://jules.google.com/task/6049412261437976789) started by @tmathmeyer*